### PR TITLE
LART-445 Implement thread pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(local_mapper_node
   src/vision/RGBCamera.cpp
   src/vision/RGBDCamera.cpp
   src/vision/Utils.cpp
+  src/post_processing/ThreadPool.cpp
 )
 ament_target_dependencies(local_mapper_node rclcpp std_msgs sensor_msgs geometry_msgs visualization_msgs lart_msgs tf2 tf2_ros tf2_eigen cv_bridge OpenCV Torch)
 

--- a/include/local_mapping_ros/post_processing/ThreadPool.h
+++ b/include/local_mapping_ros/post_processing/ThreadPool.h
@@ -1,0 +1,47 @@
+//
+// Created by carlostojal on 08-01-2024.
+//
+
+#ifndef LOCAL_MAPPING_CORE_THREADPOOL_H
+#define LOCAL_MAPPING_CORE_THREADPOOL_H
+
+#include <vector>
+#include <queue>
+#include <thread>
+#include <functional>
+#include <condition_variable>
+#include <mutex>
+
+namespace t24e::local_mapper {
+
+    /*! \brief Thread pool of fixed size for work scheduling. */
+    class ThreadPool {
+
+        private:
+            /*! \brief Number of workers. */
+            size_t numWorkers;
+
+            /*! \brief Vector of workers. */
+            std::vector<std::thread> workers;
+
+            /*! \brief Queue of pending work. */
+            std::queue<std::function<void(void)>> jobQueue;
+
+            /*! \brief Queue condition variable. Controls scheduling. */
+            std::condition_variable queueConditionVariable;
+
+            /*! \brief Queue mutex. Prevents race conditions on the queue. */
+            std::mutex queueMutex;
+
+
+        public:
+            /*! \brief Initialize a pool with a number of threads. */
+            ThreadPool(size_t numWorkers);
+
+            /*! \brief Schedule a job to the pool queue. */
+            void queueJob(std::function<void(void)> job);
+
+    };
+}
+
+#endif // LOCAL_MAPPING_CORE_THREADPOOL_H

--- a/include/local_mapping_ros/post_processing/ThreadPool.h
+++ b/include/local_mapping_ros/post_processing/ThreadPool.h
@@ -33,6 +33,12 @@ namespace t24e::local_mapper {
             /*! \brief Queue mutex. Prevents race conditions on the queue. */
             std::mutex queueMutex;
 
+            /*! \brief Should the pool stop? */
+            bool shouldStop = false;
+
+            /*! \brief Loop run by each thread in the pool waiting for work. */
+            void threadLoop();
+
 
         public:
             /*! \brief Initialize a pool with a number of threads. */
@@ -40,6 +46,10 @@ namespace t24e::local_mapper {
 
             /*! \brief Schedule a job to the pool queue. */
             void queueJob(std::function<void(void)> job);
+
+            void killAll();
+
+            size_t getNumWorkers() const;
 
     };
 }

--- a/include/local_mapping_ros/post_processing/ThreadPool.h
+++ b/include/local_mapping_ros/post_processing/ThreadPool.h
@@ -44,6 +44,9 @@ namespace t24e::local_mapper {
             /*! \brief Initialize a pool with a number of threads. */
             ThreadPool(size_t numWorkers);
 
+            /*! \brief Start the thread pool. */
+            void start();
+
             /*! \brief Schedule a job to the pool queue. */
             void queueJob(std::function<void(void)> job);
 

--- a/include/local_mapping_ros/post_processing/ThreadPool.h
+++ b/include/local_mapping_ros/post_processing/ThreadPool.h
@@ -53,7 +53,11 @@ namespace t24e::local_mapper {
             /*! \brief Schedule a job to the pool queue. */
             void queueJob(std::function<void(size_t threadIdx)> job);
 
+            /*! \brief Notify all workers to stop its job asap. */
             void killAll();
+
+            /*! \brief Is the thread busy at the moment? */
+            bool isBusy();
 
             size_t getNumWorkers() const;
 

--- a/include/local_mapping_ros/post_processing/ThreadPool.h
+++ b/include/local_mapping_ros/post_processing/ThreadPool.h
@@ -25,7 +25,7 @@ namespace t24e::local_mapper {
             std::vector<std::thread> workers;
 
             /*! \brief Queue of pending work. */
-            std::queue<std::function<void(void)>> jobQueue;
+            std::queue<std::function<void(size_t threadIdx)>> jobQueue;
 
             /*! \brief Queue condition variable. Controls scheduling. */
             std::condition_variable queueConditionVariable;
@@ -35,6 +35,9 @@ namespace t24e::local_mapper {
 
             /*! \brief Should the pool stop? */
             bool shouldStop = false;
+
+            /*! \brief Incremental index of the current thread. To be used by the programmer has he wishes. */
+            size_t currThreadIdx = 0;
 
             /*! \brief Loop run by each thread in the pool waiting for work. */
             void threadLoop();
@@ -48,7 +51,7 @@ namespace t24e::local_mapper {
             void start();
 
             /*! \brief Schedule a job to the pool queue. */
-            void queueJob(std::function<void(void)> job);
+            void queueJob(std::function<void(size_t threadIdx)> job);
 
             void killAll();
 

--- a/src/post_processing/ThreadPool.cpp
+++ b/src/post_processing/ThreadPool.cpp
@@ -105,7 +105,7 @@ namespace t24e::local_mapper {
             // acquire the mutex
             std::unique_lock<std::mutex> lk(this->queueMutex);
 
-            // the thread is not busy if the 
+            // the thread is not busy if the pool has jobs enqueued
             isBusy = !this->jobQueue.empty();
         }
         return isBusy;

--- a/src/post_processing/ThreadPool.cpp
+++ b/src/post_processing/ThreadPool.cpp
@@ -98,6 +98,19 @@ namespace t24e::local_mapper {
         this->workers.clear();
     }
 
+    bool ThreadPool::isBusy() {
+
+        bool isBusy;
+        {
+            // acquire the mutex
+            std::unique_lock<std::mutex> lk(this->queueMutex);
+
+            // the thread is not busy if the 
+            isBusy = !this->jobQueue.empty();
+        }
+        return isBusy;
+    }
+
     size_t ThreadPool::getNumWorkers() const {
         return this->numWorkers;
     }

--- a/src/post_processing/ThreadPool.cpp
+++ b/src/post_processing/ThreadPool.cpp
@@ -8,17 +8,22 @@ namespace t24e::local_mapper {
 
     ThreadPool::ThreadPool(size_t numWorkers=0) {
 
+        this->numWorkers = numWorkers;
+
+    }
+
+    void ThreadPool::start() {
+
+        this->shouldStop = false;
+
         // if no number was specified, use the number of threads of the CPU
-        if(numWorkers <= 0)
+        if(this->numWorkers <= 0)
             this->numWorkers = std::thread::hardware_concurrency();
-        else
-            this->numWorkers = numWorkers;
 
         // put all workers on the loop
         for(size_t i = 0; i < this->numWorkers; i++) {
             this->workers.emplace_back(std::thread(&ThreadPool::threadLoop, this));
         }
-
     }
 
     void ThreadPool::threadLoop() {

--- a/src/post_processing/ThreadPool.cpp
+++ b/src/post_processing/ThreadPool.cpp
@@ -1,0 +1,91 @@
+//
+// Created by carlostojal on 08-01-2024.
+//
+
+#include <local_mapping_ros/post_processing/ThreadPool.h>
+
+namespace t24e::local_mapper {
+
+    ThreadPool::ThreadPool(size_t numWorkers=0) {
+
+        // if no number was specified, use the number of threads of the CPU
+        if(numWorkers <= 0)
+            this->numWorkers = std::thread::hardware_concurrency();
+        else
+            this->numWorkers = numWorkers;
+
+        // put all workers on the loop
+        for(size_t i = 0; i < this->numWorkers; i++) {
+            this->workers.emplace_back(std::thread(&ThreadPool::threadLoop, this));
+        }
+
+    }
+
+    void ThreadPool::threadLoop() {
+
+        // run indifenitely
+        while(true) {
+            
+            std::function<void()> job;
+            {
+                // acquire the mutex
+                std::unique_lock<std::mutex> lk(this->queueMutex);
+
+                // wait for the condition variable
+                this->queueConditionVariable.wait(lk, [this]{
+                    return !this->jobQueue.empty() || this->shouldStop;
+                });
+                if(this->shouldStop)
+                    return;
+                
+                // select the next job to be done
+                job = this->jobQueue.front();
+                // remove the job from the queue
+                this->jobQueue.pop();
+            }
+            // start the job
+            job();
+        }
+
+    }
+
+    void ThreadPool::queueJob(std::function<void(void)> job) {
+
+        {
+            // acquire the job queue mutex
+            std::unique_lock<std::mutex> lk(this->queueMutex);
+
+            // add the job to the queue
+            this->jobQueue.push(job);
+        }
+
+        // notify the next free worker
+        this->queueConditionVariable.notify_one();
+    }
+
+    void ThreadPool::killAll() {
+    
+        {
+            // acquire the queue mutex
+            std::unique_lock<std::mutex> lk(this->queueMutex);
+
+            // mark to stop
+            this->shouldStop = true;
+        }
+
+        // notify all threads to stop runnning the loop
+        this->queueConditionVariable.notify_all();
+
+        // wait for each worker
+        for(std::thread& t : this->workers) {
+            t.join();
+        }
+
+        // clear the vector
+        this->workers.clear();
+    }
+
+    size_t ThreadPool::getNumWorkers() const {
+        return this->numWorkers;
+    }
+}


### PR DESCRIPTION
Implement a thread pool class to manage a pool of “x” workers assigned to processing the 6400 rows. This is better than having 6400 threads concurrently, which would most possibly be deadlocked.